### PR TITLE
Use new Obtain method to avoid delegate and closure allocation.

### DIFF
--- a/Vostok.ClusterConfig.Client/Helpers/TreeExtractor.cs
+++ b/Vostok.ClusterConfig.Client/Helpers/TreeExtractor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using JetBrains.Annotations;
+using Vostok.ClusterConfig.Client.Abstractions;
 using Vostok.Configuration.Abstractions.Merging;
 using Vostok.Configuration.Abstractions.SettingsTree;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6929808/148459044-5f24498b-446e-48a1-8487-50ec38bf1999.png)
These little guys.

This branch requires this pull request to be accepted first: https://github.com/vostok/commons.collections/pull/9